### PR TITLE
Fix ROLLBACK parse error

### DIFF
--- a/lib/slow_query_exporter/slow_query.rb
+++ b/lib/slow_query_exporter/slow_query.rb
@@ -25,7 +25,7 @@ module SlowQueryExporter
       innowait: /^#\s+InnoDB_rec_lock_wait: (\S+)\s+InnoDB_queue_wait: (\S+)/,
       innopage: /^#\s+InnoDB_pages_distinct: (\d+)/,
       time:     /^SET timestamp=(\d+)/,
-      query:    /^(DELETE|EXPLAIN|INSERT|REPLACE|SELECT|SHOW|UPDATE|COMMIT|SET|DESC(?:RIBE)?|# administrator)\b/i,
+      query:    /^(DELETE|EXPLAIN|INSERT|REPLACE|SELECT|SHOW|UPDATE|COMMIT|SET|ROLLBACK|DESC(?:RIBE)?|# administrator)\b/i,
     }
 
     attr_accessor :attributes

--- a/lib/slow_query_exporter/version.rb
+++ b/lib/slow_query_exporter/version.rb
@@ -1,3 +1,3 @@
 module SlowQueryExporter
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
We don't currently parse slow ROLLBACK statements correctly. We need to add it to the list of phrases that we expect can begin a SQL statement.