### PR TITLE
Remove rake dependency limit to 10; allows upgrade to >13 to deal with CVE-2020-8130

### DIFF
--- a/slow_query_exporter.gemspec
+++ b/slow_query_exporter.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
 
   spec.add_runtime_dependency "digest-crc", "~> 0.4"
   spec.add_runtime_dependency "gelf", "~> 3.0"


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-jppv-gw3r-w3q8