### PR TITLE
Update minimum required bundler version to address CVE-2019-3881

### DIFF
--- a/slow_query_exporter.gemspec
+++ b/slow_query_exporter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.1.0"
   spec.add_development_dependency "rake"
 
   spec.add_runtime_dependency "digest-crc", "~> 0.4"


### PR DESCRIPTION
Versions of bundler prior to `2.1.0` are vulnerable to a condition where code can be snuck in by a malicious party.