### PR TITLE
Add dependabot for automated CVE upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+registries:
+  rubygems-jfrog:
+    type: rubygems-server
+    url: https://clio.jfrog.io/clio/api/gems/product-gem-prod/
+    username: ${{secrets.ARTIFACTORY_USERNAME}}
+    password: ${{secrets.ARTIFACTORY_API_KEY}}
+
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Allow this repo to upgrade automatically for CVEs but no other dependency bumps.